### PR TITLE
feat: 여러 어플리케이션의 config가 필요한 경우에도 HTTP 통신을 한 번으로 해결할 수 있도록 한다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@day1co/spring-cloud-config-client",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/spring-cloud-config-client",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@day1co/http-request-sync": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/spring-cloud-config-client",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "NodeJS-client for Spring Cloud Config Server",
   "author": "Day1Company",
   "license": "MIT",

--- a/src/config-client/config-client.spec.fixture.ts
+++ b/src/config-client/config-client.spec.fixture.ts
@@ -1,37 +1,164 @@
-const fixture = {
+const applicationDevelopmentConfig = {
+  name: 'application-development.yml',
+  source: {
+    'database.host': 'application_dev_host',
+    'database.port': 3306,
+    'database.database': 'application_dev',
+  },
+};
+
+const applicationConfig = {
+  name: 'application.yml',
+  source: {
+    'database.host': 'localhost',
+    'database.port': 3306,
+    'database.database': 'application_local',
+    'database.pool.min': 0,
+    'database.pool.max': 10,
+    'database.timezone': 'Z', // this key only exists in application.yml
+  },
+};
+
+const fooDevelopmentConfig = {
+  name: 'foo-development.yml',
+  source: {
+    'database.host': 'foo_dev_host',
+    'database.port': 3306,
+    'database.database': 'foo_dev',
+  },
+};
+
+const fooConfig = {
+  name: 'foo.yml',
+  source: {
+    'database.host': 'localhost',
+    'database.port': 3306,
+    'database.database': 'foo_local',
+    'database.pool.min': 0,
+    'database.pool.max': 10,
+  },
+};
+
+const barDevelopmentConfig = {
+  name: 'bar-development.yml',
+  source: {
+    'database.host': 'bar_dev_host',
+    'database.port': 3306,
+    'database.database': 'bar_dev',
+  },
+};
+
+const barConfig = {
+  name: 'bar.yml',
+  source: {
+    'database.host': 'localhost',
+    'database.port': 3306,
+    'database.database': 'bar_local',
+    'database.pool.min': 0,
+    'database.pool.max': 10,
+  },
+};
+
+/**
+ * @description A mock response from Spring-Cloud-Config-Server. This default config named "application" will always be included in server responses, no matter what your custom config name is.
+ * @see https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_quick_start
+ */
+export const applicationDevelopmentRawResponse = {
+  name: 'application',
+  profiles: ['development'],
+  propertySources: [applicationConfig, applicationDevelopmentConfig],
+};
+
+/**
+ * @description an expected config which is a merged object with propertySources above.
+ */
+export const applicationDevelopmentMergedConfig = {
+  database: {
+    host: applicationDevelopmentConfig.source['database.host'],
+    port: applicationDevelopmentConfig.source['database.port'],
+    database: applicationDevelopmentConfig.source['database.database'],
+    timezone: applicationConfig.source['database.timezone'],
+    pool: {
+      min: applicationConfig.source['database.pool.min'],
+      max: applicationConfig.source['database.pool.max'],
+    },
+  },
+};
+
+/**
+ * @description a mock response from Spring-Cloud-Config-Server.
+ * @see https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_quick_start
+ */
+export const fooDevelopmentRawResponse = {
   name: 'foo',
   profiles: ['development'],
+  propertySources: [fooDevelopmentConfig, applicationDevelopmentConfig, fooConfig, applicationConfig],
+};
+
+/**
+ * @description an expected config which is a merged object with propertySources above.
+ */
+export const fooDevelopmentMergedConfig = {
+  database: {
+    host: fooDevelopmentConfig.source['database.host'],
+    port: fooDevelopmentConfig.source['database.port'],
+    database: fooDevelopmentConfig.source['database.database'],
+    timezone: applicationConfig.source['database.timezone'],
+    pool: {
+      min: fooConfig.source['database.pool.min'],
+      max: fooConfig.source['database.pool.max'],
+    },
+  },
+};
+
+/**
+ * @description a mock response from Spring-Cloud-Config-Server.
+ * @see https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_quick_start
+ */
+export const barDevelopmentRawResponse = {
+  name: 'bar',
+  profiles: ['development'],
+  propertySources: [barDevelopmentConfig, applicationDevelopmentConfig, barConfig, applicationConfig],
+};
+
+/**
+ * @description an expected config which is a merged object with propertySources above.
+ */
+export const barDevelopmentMergedConfig = {
+  database: {
+    host: barDevelopmentConfig.source['database.host'],
+    port: barDevelopmentConfig.source['database.port'],
+    database: barDevelopmentConfig.source['database.database'],
+    timezone: applicationConfig.source['database.timezone'],
+    pool: {
+      min: barConfig.source['database.pool.min'],
+      max: barConfig.source['database.pool.max'],
+    },
+  },
+};
+
+/**
+ * @description An expected response when you use multiple applications, with "name" including ",".
+ * Note that the order of multiple-application response`s propertySources is different from single-appliatoin response`s.
+ */
+export const fooBarDevelopmentRawResponse = {
+  name: 'foo,bar',
+  profiles: ['development'],
   propertySources: [
-    {
-      name: 'foo-development.yml',
-      source: {
-        'database.host': 'foo_dev_host',
-        'database.port': 3306,
-        'database.database': 'foo_dev',
-      },
-    },
-    {
-      name: 'foo.yml',
-      source: {
-        'database.host': 'localhost',
-        'database.port': 3306,
-        'database.database': 'foo_local',
-        'database.pool.min': 0,
-        'database.pool.max': 10,
-      },
-    },
+    fooDevelopmentConfig,
+    fooConfig,
+    barDevelopmentConfig,
+    barConfig,
+    applicationDevelopmentConfig,
+    applicationConfig,
   ],
 };
 
-export const mockData = JSON.stringify(fixture);
-export const mockDataSource = {
-  database: {
-    host: 'foo_dev_host',
-    port: 3306,
-    database: 'foo_dev',
-    pool: {
-      min: 0,
-      max: 10,
-    },
-  },
+/**
+ * @description an expected config which is a merged object with propertySources above.
+ */
+export const fooBarDevelopmentMergedConfig = {
+  application: applicationDevelopmentMergedConfig,
+  foo: fooDevelopmentMergedConfig,
+  bar: barDevelopmentMergedConfig,
 };

--- a/src/config-client/config-client.spec.fixture.ts
+++ b/src/config-client/config-client.spec.fixture.ts
@@ -139,17 +139,16 @@ export const barDevelopmentMergedConfig = {
 
 /**
  * @description An expected response when you use multiple applications, with "name" including ",".
- * Note that the order of multiple-application response`s propertySources is different from single-appliatoin response`s.
  */
 export const fooBarDevelopmentRawResponse = {
   name: 'foo,bar',
   profiles: ['development'],
   propertySources: [
     fooDevelopmentConfig,
-    fooConfig,
     barDevelopmentConfig,
-    barConfig,
     applicationDevelopmentConfig,
+    fooConfig,
+    barConfig,
     applicationConfig,
   ],
 };

--- a/src/config-client/config-client.ts
+++ b/src/config-client/config-client.ts
@@ -1,6 +1,5 @@
 import { httpRequestSync, httpRequestAsync, HttpResponse } from '@day1co/http-request-sync';
 import { LoggerFactory, ObjectUtil } from '@day1co/pebbles';
-import type { ObjectType } from '@day1co/pebbles';
 import { createObjectByFlattenedKey, getValueFromNestedObject } from '../utils';
 import {
   DEF_CONFIG_ENDPOINT,
@@ -15,19 +14,9 @@ import type {
   PropertySource,
 } from './config-client.interface';
 
-const logger = LoggerFactory.getLogger('spring-cloud-config-client');
+const DEFAULT_APPLICATION_NAME = 'application';
 
-function createConfigWithHttpResponse(configServerResponse: HttpResponse): Config {
-  try {
-    if (configServerResponse.error) {
-      throw new Error(JSON.stringify(configServerResponse.error));
-    }
-    return Config.getInstance(JSON.parse(configServerResponse.data));
-  } catch (err) {
-    logger.error('Response from config server is not available : %o', configServerResponse);
-    process.exit(1);
-  }
-}
+const logger = LoggerFactory.getLogger('spring-cloud-config-client');
 
 // 환경 변수로 재정의 가능
 // https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#config-data-import
@@ -41,16 +30,33 @@ export function getConfigUrl({
   return `${endpoint}/${application}/${profile}/${label}`;
 }
 
+function createConfigWithHttpResponse(configServerResponse: HttpResponse): Config {
+  if (configServerResponse.error) {
+    throw new Error(JSON.stringify(configServerResponse.error));
+  }
+  return Config.getInstance(JSON.parse(configServerResponse.data));
+}
+
 export function getConfigSync(opts?: ClientRequestOptions): Config {
-  const url = getConfigUrl(opts);
-  const configServerResponse = httpRequestSync(url);
-  return createConfigWithHttpResponse(configServerResponse);
+  try {
+    const url = getConfigUrl(opts);
+    const configServerResponse = httpRequestSync(url);
+    return createConfigWithHttpResponse(configServerResponse);
+  } catch (err) {
+    logger.error('Cannot load config. %o', err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
 }
 
 export async function getConfig(opts?: ClientRequestOptions): Promise<Config> {
-  const url = getConfigUrl(opts);
-  const configServerResponse = await httpRequestAsync(url);
-  return createConfigWithHttpResponse(configServerResponse);
+  try {
+    const url = getConfigUrl(opts);
+    const configServerResponse = await httpRequestAsync(url);
+    return createConfigWithHttpResponse(configServerResponse);
+  } catch (err) {
+    logger.error('Cannot load config. %o', err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
 }
 
 export class Config {
@@ -69,15 +75,14 @@ export class Config {
       return this.instance;
     }
 
-    const isConfigChanged = !ObjectUtil.isEqual(
-      this.instance?.createConfigObject(originalData),
-      this.instance?.configObject
-    );
+    const newConfigObject = this.instance.createConfigObject(originalData);
+    const isConfigChanged = !ObjectUtil.isEqual(newConfigObject, this.instance.configObject);
 
     if (isConfigChanged) {
       this.instance.originalData = originalData;
-      this.instance.configObject = this.instance.createConfigObject(originalData);
+      this.instance.configObject = newConfigObject;
     }
+
     return this.instance;
   }
 
@@ -96,17 +101,63 @@ export class Config {
       : this.configObject[configKey];
   }
 
-  private createConfigObject(originalData: CloudConfigResponse): ObjectType {
-    const propertySources = originalData.propertySources
+  private createConfigObject(originalData: CloudConfigResponse): ConfigObject {
+    const isMultipleApplications = originalData.name.indexOf(',') >= 0;
+
+    const configObject = isMultipleApplications
+      ? this.separateMultipleApplications(originalData)
+      : this.mergeConfigProfiles(originalData.propertySources);
+
+    const configKeys = Object.keys(configObject);
+
+    if (isMultipleApplications) {
+      return configKeys.reduce((mixedConfig: ConfigObject, applicationName) => {
+        const applicationConfig = configObject[applicationName];
+        const configKeys = Object.keys(applicationConfig);
+        mixedConfig[applicationName] = this.mergeFlattenedConfig(configKeys, applicationConfig);
+
+        return mixedConfig;
+      }, {});
+    }
+
+    return this.mergeFlattenedConfig(configKeys, configObject);
+  }
+
+  private separateMultipleApplications(originalData: CloudConfigResponse): ConfigObject {
+    const isDefaultApplicationIncluded = originalData.propertySources.some((propertySource) => {
+      return propertySource.name.includes(DEFAULT_APPLICATION_NAME);
+    });
+
+    const names = originalData.name.split(',');
+    const applicationNames = isDefaultApplicationIncluded ? names.concat(DEFAULT_APPLICATION_NAME) : names;
+
+    const separatedConfig = applicationNames.reduce((config: ConfigObject, applicationName): ConfigObject => {
+      const applicationPropertySourceList = originalData.propertySources.filter((propertySource) => {
+        // extract application name from git address string
+        // ex ) git@github.com:your-workspace/config-repo.git/foo-development.yml >> foo
+        const configApplicationName = propertySource.name.split('/').at(-1)?.split(/(\W)/gi)[0];
+        return configApplicationName === applicationName || configApplicationName === DEFAULT_APPLICATION_NAME;
+      });
+
+      const applicationConfig = this.mergeConfigProfiles(applicationPropertySourceList);
+
+      config[applicationName] = applicationConfig;
+      return config;
+    }, {});
+    return separatedConfig;
+  }
+
+  private mergeConfigProfiles(propertySources: PropertySource[]): ConfigObject {
+    const sources = propertySources
       .map((propertySource: PropertySource) => {
         return propertySource.source;
       })
       .reverse();
+    return ObjectUtil.merge({}, ...sources);
+  }
 
-    const flattenedConfig = ObjectUtil.merge({}, ...propertySources);
-    const flattenedConfigKeys = Object.keys(flattenedConfig);
-
-    const configObjectList: ConfigObject[] = flattenedConfigKeys.reduce((configList: ConfigObject[], currentKey) => {
+  private mergeFlattenedConfig(flattenedKeys: string[], flattenedConfig: ConfigObject): ConfigObject {
+    const configObjectList: ConfigObject[] = flattenedKeys.reduce((configList: ConfigObject[], currentKey) => {
       const value = this.getEnvironmentValueIfExists(currentKey) ?? flattenedConfig[currentKey];
       const isFlattened = currentKey.indexOf('.') >= 0;
 
@@ -117,7 +168,7 @@ export class Config {
       return configList.concat(configObject);
     }, []);
 
-    return ObjectUtil.merge({}, ...configObjectList);
+    return ObjectUtil.merge({}, ...configObjectList) as ConfigObject;
   }
 
   private getEnvironmentValueIfExists(key: string): string | undefined {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

### 여러 어플리케이션의 config가 필요한 경우, 어플리케이션 수만큼 Spring Cloud Server와 HTTP 통신을 한다. 네트워크 통신 횟수를 줄이고자 한다.

현재 데이원의 많은 서버들은 여러 어플리케이션의 config를 조합해서 쓰고 있다.
ex) fastcampus, coloso, zerobase, backoffice, and so on ...

그래서 서버 부팅때마다 Spring Cloud Server 호출을 여러번 하고 있다.

GET http://{configUrl}/fastcampus
GET http://{configUrl}/coloso
GET http://{configUrl}/zerobase
GET http://{configUrl}/backoffice
... and so on

그리고 어플리케이션의 수는 계속 늘어나는 중이다.

### 어떤 상황에서든 Config를 로드하는데 실패했다면, process를 kill해야 한다.

현재 process.exit(1) 코드는 Spring Cloud Server에서 에러 객체를 리턴한 경우에만 호출된다.
하지만 Spring Cloud Server의 리스폰스를 받기 전, `httpRequestSync()`, `httpRequestAsync()` 코드 내에서도 에러를 내뱉는 상황이 있을 수 있는데, 이런 케이스에 대한 처리가 되어있지 않다.

## 무엇을 어떻게 변경했나요?
1. application 이름으로 fastcampus,coloso,zerobase 와 같이 콤마로 구분된 스트링이 들어온다면 아래와 같이 생긴 Config 객체를 만듭니다.
```javascript
{
  appliation: {
    // ...
  },
  fastcampus: {
    // ...
  },
  coloso: {
    // ...
  },
  zerobase: {
    // ...
  },
}
```

2. getConfigSync(), getConfig() 에서 try/catch 처리를 하도록 합니다.
3. 테스트픽스쳐에 description을 달아, spring cloud 에 대한 이해도가 낮아도 해당 모듈의 이해를 돕도록 합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
spring cloud config server의 소스코드를 참고했습니다.

https://github.com/spring-cloud/spring-cloud-config/blob/542f3e793edb1efb04a6f1f3d0101f729b2de46f/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java#L121

## 어떻게 테스트 하셨나요?
스모크

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="816" alt="Screenshot 2023-07-19 at 7 10 35 PM" src="https://github.com/day1co/spring-cloud-config-client/assets/63729090/3e8e1f5b-a558-4a9e-8359-d4f84e1b2ef9">

```javascript
  const x = getConfigSync({
    application: 'fastcampus,coloso,zerobase',
    endpoint: 'http://configserver…',
    profile: 'development',
  });

  console.log(x.all.fastcampus.storage);
  console.log('=========');
  console.log(x.all.coloso.storage);
  console.log('=========');
  console.log(x.all.zerobase.storage);
```

결과
```javascript
{
  gcsProjectId: 'day1-dev',
  asset: {
    name: 'gcs-day1-dev-static',
    prefix: 'dev',
    publicUrl: 'https://storage.googleapis.com/gcs-day1-dev-static/'
  },
  report: { name: 'fc-exports-dev', prefix: '', publicUrl: '' },
  settlement: {
    name: 'gcs-day1-development-settlement-export',
    projectId: 'day1-dev',
    prefix: '',
    publicUrl: ''
  },
  billingAccount: {
    name: 'gcs-day1-development-billing-account-attachments',
    prefix: '',
    publicUrl: ''
  }
}
=========
{
  gcsProjectId: 'day1-dev',
  asset: {
    name: 'gcs-day1-dev-static',
    prefix: 'dev',
    publicUrl: 'https://storage.googleapis.com/gcs-day1-dev-static/'
  },
  report: { name: 'gcs-day1-development-report', prefix: '', publicUrl: '' },
  settlement: {
    name: 'gcs-day1-development-settlement-export',
    projectId: 'day1-dev',
    prefix: '',
    publicUrl: ''
  },
  billingAccount: {
    name: 'gcs-day1-development-billing-account-attachments',
    prefix: '',
    publicUrl: ''
  },
  translation: { name: 'gcs-coloso-dev-translation', prefix: '', publicUrl: '' }
}
=========
{
  gcsProjectId: 'day1-dev',
  asset: {
    name: 'gcs-day1-dev-static',
    prefix: 'dev',
    publicUrl: 'https://storage.googleapis.com/gcs-day1-dev-static/'
  },
  report: { name: 'fc-exports-dev', prefix: '', publicUrl: '' },
  settlement: {
    name: 'gcs-day1-development-settlement-export',
    projectId: 'day1-dev',
    prefix: '',
    publicUrl: ''
  },
  billingAccount: {
    name: 'gcs-day1-development-billing-account-attachments',
    prefix: '',
    publicUrl: ''
  }
}
```