### PR TITLE
Feat/custom config value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@day1co/http-request-sync": "0.0.3",
+        "@day1co/http-request-sync": "0.0.4",
         "@day1co/pebbles": "~3.0.1"
       },
       "devDependencies": {
@@ -620,9 +620,9 @@
       "dev": true
     },
     "node_modules/@day1co/http-request-sync": {
-      "version": "0.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@day1co/http-request-sync/0.0.3/d5706c5337a9b3a1201bcd306797e94234e9846a3a224e99452c4d0988a73e15",
-      "integrity": "sha512-apX853/X9L/ALS04mFs1mOmkAFlbrwlIfi8W6PMmamP6kE3q1no2tEIwhfda0lAeEDD0u+f/LGDS5j4bDTXU0w==",
+      "version": "0.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@day1co/http-request-sync/0.0.4/81148c50b5a3475105047c33ee6a3a523c8f422ead6801f9dd5f9b31cc4210ec",
+      "integrity": "sha512-95rCAaK3vz4G006UROc+o+ezn/RY/gAeInCr/oIdW0gQ0/zGq9Trka9VP6Swe6N+IVHi+bFwv7Or3+ok7b9t2Q==",
       "license": "MIT"
     },
     "node_modules/@day1co/pebbles": {
@@ -6816,9 +6816,9 @@
       "dev": true
     },
     "@day1co/http-request-sync": {
-      "version": "0.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@day1co/http-request-sync/0.0.3/d5706c5337a9b3a1201bcd306797e94234e9846a3a224e99452c4d0988a73e15",
-      "integrity": "sha512-apX853/X9L/ALS04mFs1mOmkAFlbrwlIfi8W6PMmamP6kE3q1no2tEIwhfda0lAeEDD0u+f/LGDS5j4bDTXU0w=="
+      "version": "0.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@day1co/http-request-sync/0.0.4/81148c50b5a3475105047c33ee6a3a523c8f422ead6801f9dd5f9b31cc4210ec",
+      "integrity": "sha512-95rCAaK3vz4G006UROc+o+ezn/RY/gAeInCr/oIdW0gQ0/zGq9Trka9VP6Swe6N+IVHi+bFwv7Or3+ok7b9t2Q=="
     },
     "@day1co/pebbles": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@day1co/http-request-sync": "0.0.3",
+    "@day1co/http-request-sync": "0.0.4",
     "@day1co/pebbles": "~3.0.1"
   },
   "devDependencies": {

--- a/src/config-client/config-client.spec.fixture.ts
+++ b/src/config-client/config-client.spec.fixture.ts
@@ -1,5 +1,3 @@
-import { ObjectUtil } from '@day1co/pebbles';
-
 const fixture = {
   name: 'foo',
   profiles: ['development'],
@@ -7,29 +5,33 @@ const fixture = {
     {
       name: 'foo-development.yml',
       source: {
-        database: {
-          host: 'foo_dev_host',
-          port: 3306,
-          database: 'foo_dev',
-        },
+        'database.host': 'foo_dev_host',
+        'database.port': 3306,
+        'database.database': 'foo_dev',
       },
     },
     {
       name: 'foo.yml',
       source: {
-        database: {
-          host: 'localhost',
-          port: 3306,
-          database: 'foo_local',
-          pool: {
-            min: 0,
-            max: 10,
-          },
-        },
+        'database.host': 'localhost',
+        'database.port': 3306,
+        'database.database': 'foo_local',
+        'database.pool.min': 0,
+        'database.pool.max': 10,
       },
     },
   ],
 };
 
 export const mockData = JSON.stringify(fixture);
-export const mockDataSource = ObjectUtil.merge({}, ...fixture.propertySources.reverse()).source;
+export const mockDataSource = {
+  database: {
+    host: 'foo_dev_host',
+    port: 3306,
+    database: 'foo_dev',
+    pool: {
+      min: 0,
+      max: 10,
+    },
+  },
+};

--- a/src/config-client/config-client.spec.ts
+++ b/src/config-client/config-client.spec.ts
@@ -42,6 +42,13 @@ describe('configClient', () => {
     done();
   });
 
+  test('error response', () => {
+    expect(() => getConfigSync({ endpoint: '', application: '' })).toThrow();
+    expect(() => getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'invalid' })).toThrow();
+    expect(() => getConfigSync({ endpoint: `http://localhost:88888`, application: 'foo' })).toThrow();
+    expect(() => getConfigSync({ endpoint: `localhost:${testPort}`, application: 'foo' })).toThrow();
+  });
+
   test('instance', () => {
     expect(config instanceof Config).toBe(true);
   });
@@ -68,9 +75,5 @@ describe('configClient', () => {
     const config = getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'foo' });
     expect(config.getByKey('database')).not.toEqual(mockDataSource.database);
     expect(config.getByKey('database.database')).toBe(process.env.DATABASE_DATABASE);
-  });
-
-  test('error response', () => {
-    expect(() => getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'invalid' })).toThrow();
   });
 });

--- a/src/config-client/config-client.spec.ts
+++ b/src/config-client/config-client.spec.ts
@@ -62,6 +62,14 @@ describe('configClient', () => {
     expect(config.getByKey('database.pool.min')).toEqual(mockDataSource.database.pool.min);
   });
 
+  test('getByKey with custom environment variable', () => {
+    process.env.DATABASE_DATABASE = 'foo_custom';
+
+    const config = getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'foo' });
+    expect(config.getByKey('database')).not.toEqual(mockDataSource.database);
+    expect(config.getByKey('database.database')).toBe(process.env.DATABASE_DATABASE);
+  });
+
   test('error response', () => {
     expect(() => getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'invalid' })).toThrow();
   });

--- a/src/config-client/config-client.ts
+++ b/src/config-client/config-client.ts
@@ -62,10 +62,7 @@ export class Config {
     const flattenedConfigKeys = Object.keys(flattenedConfig);
 
     const configObjectList: ConfigObject[] = flattenedConfigKeys.reduce((configList: ConfigObject[], currentKey) => {
-      const environmentVariableKey = currentKey.replaceAll('.', '_').toUpperCase();
-      const customValue = process.env[environmentVariableKey];
-
-      const value = customValue ?? flattenedConfig[currentKey];
+      const value = this.getEnvironmentValueIfExists(currentKey) ?? flattenedConfig[currentKey];
       const isFlattened = currentKey.indexOf('.') >= 0;
 
       const configObject = isFlattened
@@ -76,5 +73,10 @@ export class Config {
     }, []);
 
     return ObjectUtil.merge({}, ...configObjectList);
+  }
+
+  private getEnvironmentValueIfExists(key: string): string | undefined {
+    const environmentVariableKey = key.replaceAll('.', '_').toUpperCase();
+    return process.env[environmentVariableKey];
   }
 }

--- a/src/config-client/config-client.ts
+++ b/src/config-client/config-client.ts
@@ -62,7 +62,10 @@ export class Config {
     const flattenedConfigKeys = Object.keys(flattenedConfig);
 
     const configObjectList: ConfigObject[] = flattenedConfigKeys.reduce((configList: ConfigObject[], currentKey) => {
-      const value = flattenedConfig[currentKey];
+      const environmentVariableKey = currentKey.replaceAll('.', '_').toUpperCase();
+      const customValue = process.env[environmentVariableKey];
+
+      const value = customValue ?? flattenedConfig[currentKey];
       const isFlattened = currentKey.indexOf('.') >= 0;
 
       const configObject = isFlattened


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
- config-server에서 불러온 값 외에 설정하고 싶은 config value를 덮어쓸 수 있도록 한다

## 무엇을 어떻게 변경했나요?
createConfigObject 메서드 로직 수정
spec.fixture를 실제 config-server response와 동일하게 수정

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
현재 개발환경에서 원하는 config 값들을 override하는 경우가 있습니다.
대표 예시 : 현 redstone-config 의 local.js 파일
이러한 현황에 혼선이 없도록 하기 위해 process.env에서 동일한 값이 있을시, 해당 process.env value를 덮어쓸 수 있도록 합니다.

## 디펜던시 변경이 있나요?
http-request-sync to 0.0.4

## 어떻게 테스트 하셨나요?
npm test

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
