### PR TITLE
fix: ClientRequestOptions` application member to be optional

### DIFF
--- a/src/config-client/config-client.interface.ts
+++ b/src/config-client/config-client.interface.ts
@@ -1,6 +1,6 @@
 export interface ClientRequestOptions {
   endpoint: string;
-  application: string;
+  application?: string;
   profile?: string;
   label?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { getConfigSync, getConfig, Config } from './config-client/config-client';
 export { createObjectByFlattenedKey, getValueFromNestedObject } from './utils';
+export { startMockServer } from './embedded-server';
 export type {
   ClientRequestOptions,
   CloudConfigResponse,
   ConfigObject,
   PropertySource,
 } from './config-client/config-client.interface';
-export { startMockServer } from './embedded-server';


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
default value가 있으므로 해당 타입을 optional로 지정합니다

## 무엇을 어떻게 변경했나요?
ClientRequestOptions의 application 멤버를 optional로 변경
