### PR TITLE
fix: Process.exit(1) if parsing response data failed

### DIFF
--- a/src/config-client/config-client.spec.ts
+++ b/src/config-client/config-client.spec.ts
@@ -86,6 +86,9 @@ describe('configClient', () => {
     });
 
     test('error response', () => {
+      jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw 'Test:process.exit()';
+      });
       expect(() => getConfigSync({ endpoint: '', application: '' })).toThrow();
       expect(() => getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'invalid' })).toThrow();
       expect(() => getConfigSync({ endpoint: `http://localhost:88888`, application: 'foo' })).toThrow();

--- a/src/config-client/config-client.ts
+++ b/src/config-client/config-client.ts
@@ -1,5 +1,5 @@
 import { httpRequestSync, httpRequestAsync, HttpResponse } from '@day1co/http-request-sync';
-import { ObjectUtil } from '@day1co/pebbles';
+import { LoggerFactory, ObjectUtil } from '@day1co/pebbles';
 import type { ObjectType } from '@day1co/pebbles';
 import { createObjectByFlattenedKey, getValueFromNestedObject } from '../utils';
 import {
@@ -15,12 +15,18 @@ import type {
   PropertySource,
 } from './config-client.interface';
 
+const logger = LoggerFactory.getLogger('spring-cloud-config-client');
+
 function createConfigWithHttpResponse(configServerResponse: HttpResponse): Config {
-  if (configServerResponse.error) {
-    throw new Error(JSON.stringify(configServerResponse.error));
+  try {
+    if (configServerResponse.error) {
+      throw new Error(JSON.stringify(configServerResponse.error));
+    }
+    return Config.getInstance(JSON.parse(configServerResponse.data));
+  } catch (err) {
+    logger.error('Response from config server is not available : %o', configServerResponse);
+    process.exit(1);
   }
-  const originalData = JSON.parse(configServerResponse.data);
-  return Config.getInstance(originalData);
 }
 
 // 환경 변수로 재정의 가능


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
config server에서 전달해주는 에러 객체도 없는데, data 도 없어서 JSON.parse() 시 에러가 나는 것 같습니다.
<img width="1061" alt="Screenshot 2023-04-18 at 11 44 10 AM" src="https://user-images.githubusercontent.com/63729090/232657061-e2aa6abe-3f4b-4ee0-9679-db6d9d9152ac.png">

## 무엇을 어떻게 변경했나요?
try catch 적용해서 JSON.parse() 실패시 process.exit 하고 컨피그 response 로깅하도록 합니다

## 어떻게 테스트 하셨나요?
스모크테스트
