### PR TITLE
misc: downgrade ts compiler and config settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@day1co/spring-cloud-config-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/spring-cloud-config-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@day1co/http-request-sync": "~1.0.1",
@@ -16,6 +16,7 @@
         "@day1co/eslint-config": "^1.0.0",
         "@day1co/prettier-config": "^1.0.0",
         "@day1co/tsconfig": "^1.2.1",
+        "@tsconfig/node-lts": "^18.12.1",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.4.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -29,7 +30,7 @@
         "prettier": "^2.8.8",
         "rimraf": "^5.0.0",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.0.0"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1712,9 +1713,9 @@
       }
     },
     "node_modules/@tsconfig/node-lts": {
-      "version": "18.12.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.3.tgz",
-      "integrity": "sha512-a8FraAjwaGKERCO5PowJeeCE/0Kv1whqegfNwJRIPG08Z5QDr6Kl1CgRrdIjGQtUCpSm+/BDCGeRKfAF1mg+ZQ==",
+      "version": "18.12.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
+      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -8174,16 +8175,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/spring-cloud-config-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NodeJS-client for Spring Cloud Config Server",
   "author": "Day1Company",
   "license": "MIT",
@@ -33,6 +33,7 @@
     "@day1co/eslint-config": "^1.0.0",
     "@day1co/prettier-config": "^1.0.0",
     "@day1co/tsconfig": "^1.2.1",
+    "@tsconfig/node-lts": "^18.12.1",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.4.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -46,6 +47,6 @@
     "prettier": "^2.8.8",
     "rimraf": "^5.0.0",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.0.0"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 메인터넌스

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

본 패키지만 TS5 버전으로 빌드되어 기존 4.x 빌드 패키지와 type 호환이 되지 않는 문제가 있습니다.
redstone 5.1 은 TS4 버전을 사용합니다.

## 무엇을 어떻게 변경했나요?

현행 우리가 사용하는 버전으로 다운그레이드 빌드 배포

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

TS5 업그레이드는 prettier 3.x 적용과 같은 시간에 업그레이드 준비해 보겠습니다.

