### PR TITLE
fix: spring cloud error handling

### DIFF
--- a/src/config-client/config-client.interface.ts
+++ b/src/config-client/config-client.interface.ts
@@ -5,7 +5,7 @@ export interface ClientRequestOptions {
   label?: string;
 }
 
-export interface CloudConfigResponse {
+export interface CloudConfigSuccessResponse {
   name: string;
   profiles: string[];
   label?: string;
@@ -13,6 +13,15 @@ export interface CloudConfigResponse {
   state?: string;
   propertySources: PropertySource[];
 }
+
+export interface CloudConfigErrorResponse {
+  timestamp: string;
+  status: number;
+  error: string;
+  path: string;
+}
+
+export type CloudConfigResponse = CloudConfigSuccessResponse | CloudConfigErrorResponse;
 
 export interface ConfigObject {
   [x: string]: any;

--- a/src/config-client/config-client.spec.ts
+++ b/src/config-client/config-client.spec.ts
@@ -70,8 +70,10 @@ describe('configClient', () => {
             res.end(fooMockData);
           } else if (req.url.startsWith('/bar')) {
             res.end(barMockData);
-          } else if (req.url.startsWith('/invalid')) {
-            res.end(JSON.stringify({ error: { errno : 0, code : 'err' } }));
+          } else if (req.url.startsWith('/protocol-error')) {
+            res.end(JSON.stringify({ error : { errno : 0, code : 'err' } }));
+          } else if (req.url.startsWith('/404')) {
+            res.end(JSON.stringify({ data : { error : 'Not Found' } }));
           };
         }).listen(testPort);
         server.on('clientError', (err, socket) => {
@@ -113,11 +115,12 @@ describe('configClient', () => {
       jest.spyOn(process, 'exit').mockReturnThis();
 
       getConfigSync({ endpoint: '', application: '' });
-      getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'invalid' });
+      getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'protocol-error' });
+      getConfigSync({ endpoint: `http://localhost:${testPort}`, application: '404' });
       getConfigSync({ endpoint: `http://localhost:88888`, application: 'foo' });
       getConfigSync({ endpoint: `localhost:${testPort}`, application: 'foo' });
 
-      expect(process.exit).toBeCalledTimes(4);
+      expect(process.exit).toBeCalledTimes(5);
     });
     test('assurance of a sole instance', () => {
       const barConfig = getConfigSync({ endpoint: `http://localhost:${testPort}`, application: 'bar' });
@@ -172,8 +175,10 @@ describe('configClient', () => {
               res.end(JSON.stringify(fooDevelopmentRawResponse));
             } else if (req.url.startsWith('/bar')) {
               res.end(JSON.stringify(barDevelopmentRawResponse));
-            } else if (req.url.startsWith('/invalid')) {
+            } else if (req.url.startsWith('/protocol-error')) {
               res.end(JSON.stringify({ error: { errno: 0, code: 'err' } }));
+            } else if (req.url.startsWith('/404')) {
+              res.end(JSON.stringify({ data: { error: 'Not Found' } }));
             }
           }
         })
@@ -200,11 +205,12 @@ describe('configClient', () => {
       jest.spyOn(process, 'exit').mockReturnThis();
 
       await getConfig({ endpoint: '', application: '' });
-      await getConfig({ endpoint: `http://localhost:${testPort}`, application: 'invalid' });
+      await getConfig({ endpoint: `http://localhost:${testPort}`, application: 'protocol-error' });
+      await getConfig({ endpoint: `http://localhost:${testPort}`, application: '404' });
       await getConfig({ endpoint: `http://localhost:88888`, application: 'foo' });
       await getConfig({ endpoint: `localhost:${testPort}`, application: 'foo' });
 
-      expect(process.exit).toBeCalledTimes(4);
+      expect(process.exit).toBeCalledTimes(5);
     });
     test('assurance of a sole instance', async () => {
       const barConfig = await getConfig({ endpoint: `http://localhost:${testPort}`, application: 'bar' });


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
네트워크 통신중에 대한 에러 처리만 되어있었지 spring cloud config 에서 전달하는 에러에 대한 처리가 안되어있음.
config가 invalid할때 에러 메세지를 프렌들리하게 설정

## 무엇을 어떻게 변경했나요?
http 응답 결과 내 data.error 키가 있는 경우에 대한 에러메세지 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
현재 메세지
<img width="700" alt="Screenshot 2023-11-24 at 1 59 48 PM" src="https://github.com/day1co/spring-cloud-config-client/assets/63729090/37c75094-e051-4f8c-b24b-d83fa285a849">

## 디펜던시 변경이 있나요?
x

## 어떻게 테스트 하셨나요?
스모크

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
```
{"level":50,"time":1700801683914,"pid":30331,"hostname":"munhuiwons-MacBook-Pro.local","name":"spring-cloud-config-client","msg":"Cannot load config. 'Not Found. Check if your request was valid : /invalid-test/default/sabotaging'"}
```