### PR TITLE
fix: Export EmbeddedServer from the root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { getConfigSync, getConfig, Config } from './config-client/config-client';
 export { createObjectByFlattenedKey, getValueFromNestedObject } from './utils';
-export { startMockServer } from './embedded-server';
+export { startMockServer, EmbeddedServer } from './embedded-server';
 export {
   DEF_CONFIG_ENDPOINT,
   DEF_CONFIG_APPLICATION,


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
EmbeddedServer 클래스를 root에서 export하지 않고 있다.

## 무엇을 어떻게 변경했나요?
root index에서 export 하도록 변경
